### PR TITLE
Add mock intro and notes sections to Consent profile

### DIFF
--- a/input/intro-notes/StructureDefinition-FASTConsent-intro.md
+++ b/input/intro-notes/StructureDefinition-FASTConsent-intro.md
@@ -1,0 +1,22 @@
+
+The following Intro section is a mock up of expected requirements - **This highlighting will be removed prior to publication.**
+{:.new-content}
+
+### Mandatory and Must Support Data Elements
+
+The following data elements must always be present or must be supported if the data is present in the sending system [Must Support]({{site.data.fhir.path}}conformance-rules.html#mustSupport). They are presented below in a simple human-readable explanation. Profile specific guidance and examples are provided as well. The [Formal Views](#profile) below provides the formal summary, definitions, and terminology requirements.  
+
+**Each Consent Must Have:**
+
+1. a scope
+1. a patient
+1. a dateTime
+1. a performer
+1. a organization
+1. a source[x]
+1. a provision
+
+**Each Consent Must Support:**
+
+1. all Must Have
+1. a provision.type

--- a/input/intro-notes/StructureDefinition-FASTConsent-notes.md
+++ b/input/intro-notes/StructureDefinition-FASTConsent-notes.md
@@ -1,0 +1,81 @@
+
+The following Notes section is a mock up of expected requirements - **This highlighting will be removed prior to publication.**
+{:.new-content}
+
+---
+
+**Quick Start**{:#search style="font-size: 20px;"}
+<a name="quick-start"> </a>
+
+---
+
+Below is an overview of the required Server RESTful FHIR interactions for this profile - for example, search and read operations - when supporting the FAST Consent interactions to access this profile's information (Profile Support + Interaction Support). See the FAST Consent Server CapabilityStatement (TBD) for a complete list of supported RESTful interactions for this IG.
+
+- See the [SMART App Launch - Scopes and Launch Context]({{site.data.fhir.ver.hl7_fhir_uv_smart_app_launch}}scopes-and-launch-context.html) section for a description of the SMART scopes syntax.
+- See the [Search Syntax]({{site.data.fhir.path}}search.html) section for a description of the FHIR search syntax.
+
+#### FAST Consent Scopes
+Servers providing access to patient consent data SHALL support these FAST Consent SMART Scopes:
+
+- [resource level scopes]({{site.data.fhir.ver.hl7_fhir_uv_smart_app_launch}}scopes-and-launch-context.html#scopes-for-requesting-clinical-data) `<patient|user|system>/Consent.crus`
+
+#### Mandatory Search Parameters:
+
+The following search parameters and search parameter combinations SHALL be supported:
+
+1. **SHALL** support both read Consent by `id` **AND** Consent search using the **[`_id`]({{site.data.fhir.path}}search.html#id)** search parameter:
+
+    `GET [base]/Consent/[id]` or `GET [base]/Consent?_id=[id]`
+
+    Example:
+    
+      1. GET [base]/Consent/1032702
+      1. GET [base]/Consent?_id=1032702
+
+    *Implementation Notes:*  ([how to search by the logical id]({{site.data.fhir.path}}references.html#logical) of the resource)
+
+1. **SHALL** support searching a consent by an identifier such as a CDA consent document using the **[`identifier`]({{site.data.fhir.path}}search.html#token)** search parameter:
+
+    `GET [base]/Consent?identifier={system|}[code]`
+
+    Example:
+    
+      1. GET [base]/Consent?identifier=http://hospital.smarthealthit.org\|1032702
+
+    *Implementation Notes:* Fetches a bundle containing any Consent resources matching the identifier ([how to search by token]({{site.data.fhir.path}}search.html#token))
+
+1. **SHALL** support searching a consent by a patient using the **[`patient`]({{site.data.fhir.path}}search.html#reference)** search parameter:
+
+    `GET [base]/Consent?patient={type\}[id]`
+
+    Example:
+    
+      1. GET [base]/Consent?patient=Patient\1032702
+
+    *Implementation Notes:* Fetches a bundle containing any Consent resources matching the patient ([how to search by reference]({{site.data.fhir.path}}search.html#reference))
+
+1. **SHALL** support searching using the combination of the **[`patient`]({{site.data.fhir.path}}search.html#reference)** and **[`status`]({{site.data.fhir.path}}search.html#token)** search parameters:
+
+    `GET [base]/Patient?patient={type\}[id]&amp;status=[code]`
+
+    Example:
+    
+      1. GET [base]/Patient?patient=Patient\1032702&amp;status=active
+
+    *Implementation Notes:* Fetches a bundle of all Consent resources matching the specified patient and status ([how to search by reference]({{site.data.fhir.path}}search.html#reference) and [how to search by token]({{site.data.fhir.path}}search.html#token))
+
+
+#### Optional Search Parameters:
+
+The following search parameter combinations **SHOULD** be supported:
+
+1. **SHOULD** support searching using the combination of the **[`patient`]({{site.data.fhir.path}}search.html#reference)** and **[`date`]({{site.data.fhir.path}}search.html#date)** search parameters:
+
+    `GET [base]/Patient?patient={type\}[id]&amp;date=[date]`
+
+    Example:
+    
+      1. GET [base]/Patient?patient=Patient\1032702&amp;date=2024-03-20
+
+    *Implementation Notes:* Fetches a bundle of all Patient resources matching the specified patient and date ([how to search by reference]({{site.data.fhir.path}}search.html#reference) and [how to search by date]({{site.data.fhir.path}}search.html#date))
+

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -85,6 +85,15 @@ pages:
 #   excludettl: true
 #   validation: [allow-any-extensions, no-broken-links]
 #
+parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+  path-resource:
+    - input/resources
+    - fsh-generated/resources
+  path-pages:
+    - input/pagecontent
+    - input/intro-notes
+    - fsh-generated/includes
+
 # ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
 # │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
 # │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │


### PR DESCRIPTION
### What does this Pull Request do?
Add mock intro and notes sections to FAST Consent Profile.

Additional update to the sushi-config.yaml file to explicitly define the parameters for "path-resource" and "path-pages".

### Why?
These sections were copied from the US Core Patient Profile and then updated to mock a proposed format for the Consent Profile.